### PR TITLE
fix: unquoted custom properties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -251,7 +251,7 @@ module.exports = class Breakpoints {
     if (this.#config.css.customProperty) {
       string += `${this.#config.css.element} {`;
       this.#customProperties.forEach((customProperty) => {
-        string += `--${customProperty.name}: "${customProperty.value}";`;
+        string += `--${customProperty.name}: ${customProperty.value};`;
       });
       string += `}`;
     }


### PR DESCRIPTION
CSS Custom Properties should be unquoted so the value can be used as a length unit. With quotes the value is only usable as a string.